### PR TITLE
Update psycopg2 for docker image to function

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ django-controlcenter===0.2.6
 django-environ==0.4.1
 
 # Python-PostgreSQL Database Adapter
-psycopg2==2.7
+psycopg2-binary==2.7.3.2
 
 # Unicode slugification
 awesome-slugify==1.6.5


### PR DESCRIPTION
Was getting

```
ImportError: /usr/local/lib/python2.7/site-packages/psycopg2/.libs/./libresolv-2-c4c53def.5.so: symbol __res_maybe_init version GLIBC_PRIVATE not defined in file libc.so.6 with link time reference
```

Updated psycopg package works.